### PR TITLE
Ee 26903 drone push to quay

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
     when:
@@ -64,7 +64,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
     when:
@@ -79,7 +79,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:build-$${DRONE_BUILD_NUMBER}
@@ -95,7 +95,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}

--- a/.drone.yml
+++ b/.drone.yml
@@ -51,7 +51,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_euro_tlr_enquiry_form" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
     when:
@@ -64,7 +64,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_euro_tlr_enquiry_form" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
     when:
@@ -79,7 +79,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_euro_tlr_enquiry_form" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:build-$${DRONE_BUILD_NUMBER}
@@ -95,7 +95,7 @@ pipeline:
     secrets:
       - docker_password
     commands:
-      - docker login -u="ukhomeofficedigital+pttg_ip_smoke_tests" -p=$${DOCKER_PASSWORD} quay.io
+      - docker login -u="ukhomeofficedigital+pttg_euro_tlr_enquiry_form" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
       - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
       - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,67 +10,99 @@ pipeline:
     when:
       event: push
 
-  # lint:
-  #   group: build
-  #   image: quay.io/ukhomeofficedigital/nodejs-base:v8.11.1
-  #   commands:
-  #     - npm install eslint
-  #     - npm run test:lint
-  #   when:
-  #     event: push
-  #
-  # build-test:
-  #   group: build
-  #   image: docker:18.03.1-ce
-  #   environment:
-  #     - DOCKER_HOST=tcp://172.17.0.1:2375
-  #   commands:
-  #     - docker build -f Dockerfile_test -t test-$${DRONE_COMMIT_SHA} .
-  #   when:
-  #     event: push
-  #
-  # test:
-  #   group: test
-  #   image: docker:18.03.1-ce
-  #   environment:
-  #     - DOCKER_HOST=tcp://172.17.0.1:2375
-  #   commands:
-  #     - docker run -d --name=redis-$${DRONE_COMMIT_SHA} redis
-  #     - docker run -d -e NODE_ENV=ci --name=app-$${DRONE_COMMIT_SHA} --net=container:redis-$${DRONE_COMMIT_SHA} pttg-rps-enquiry
-  #     - docker run -d --net=container:app-$${DRONE_COMMIT_SHA} --name=selenium-$${DRONE_COMMIT_SHA} selenium/standalone-chrome
-  #     - docker run --rm --net=container:selenium-$${DRONE_COMMIT_SHA} -e SELENIUM_TCP=tcp://localhost:4444 martin/wait
-  #     - docker run --rm --net=container:app-$${DRONE_COMMIT_SHA} test-$${DRONE_COMMIT_SHA}
-  #     - docker rm -vf "app-$${DRONE_COMMIT_SHA}" "redis-$${DRONE_COMMIT_SHA}"
-  #   when:
-  #     event: push
-  #
-  # install-docker-image:
-  #   image: docker:18.03.1-ce
-  #   environment:
-  #     - DOCKER_HOST=tcp://172.17.0.1:2375
-  #   secrets:
-  #     - docker_password
-  #   commands:
-  #     - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-  #     - docker tag pttg-rps-enquiry quay.io/ukhomeofficedigital/pttg-rps-enquiry:build-$${DRONE_BUILD_NUMBER}
-  #     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry:build-$${DRONE_BUILD_NUMBER}
-  #   when:
-  #     branch: master
-  #     event: push
-  #
-  # tag-docker-image-with-git-tag:
-  #   image: docker:18.03.1-ce
-  #   environment:
-  #     - DOCKER_HOST=tcp://172.17.0.1:2375
-  #   secrets:
-  #     - docker_password
-  #   commands:
-  #     - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-  #     - docker tag pttg-rps-enquiry quay.io/ukhomeofficedigital/pttg-rps-enquiry:$${DRONE_TAG}
-  #     - docker push quay.io/ukhomeofficedigital/pttg-rps-enquiry:$${DRONE_TAG}
-  #   when:
-  #     event: tag
-  #
+  lint:
+    group: build
+    image: quay.io/ukhomeofficedigital/nodejs-base:v8.11.1
+    commands:
+      - npm install eslint
+      - npm run test:lint
+    when:
+      event: push
+
+  build-test:
+    group: build
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker build -f Dockerfile_test -t test-$${DRONE_COMMIT_SHA} .
+    when:
+      event: push
+
+  test:
+    group: test
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    commands:
+      - docker run -d --name=redis-$${DRONE_COMMIT_SHA} redis
+      - docker run -d -e NODE_ENV=ci --name=app-$${DRONE_COMMIT_SHA} --net=container:redis-$${DRONE_COMMIT_SHA} pttg-euro-tlr-enquiry
+      - docker run -d --net=container:app-$${DRONE_COMMIT_SHA} --name=selenium-$${DRONE_COMMIT_SHA} selenium/standalone-chrome
+      - docker run --rm --net=container:selenium-$${DRONE_COMMIT_SHA} -e SELENIUM_TCP=tcp://localhost:4444 martin/wait
+      - docker run --rm --net=container:app-$${DRONE_COMMIT_SHA} test-$${DRONE_COMMIT_SHA}
+      - docker rm -vf "app-$${DRONE_COMMIT_SHA}" "redis-$${DRONE_COMMIT_SHA}"
+    when:
+      event: push
+
+  install-docker-image-with-githash-tag:
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+      - docker_password
+    commands:
+      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+    when:
+      event: push
+
+  install-docker-image-from-feature-branch-build:
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+      - docker_password
+    commands:
+      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_BRANCH}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_BRANCH}
+    when:
+      branch:
+        exclude: master
+      event: push
+
+  install-docker-image-from-master-branch-build:
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+      - docker_password
+    commands:
+      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:latest
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:latest
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:build-$${DRONE_BUILD_NUMBER}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:build-$${DRONE_BUILD_NUMBER}
+    when:
+      branch: master
+      event: push
+
+  tag-docker-image-with-git-tag:
+    image: docker:18.03.1-ce
+    environment:
+      - DOCKER_HOST=tcp://172.17.0.1:2375
+    secrets:
+      - docker_password
+    commands:
+      - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:$${DRONE_TAG}
+      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+    when:
+      event: tag
+
   # clone-kube-project:
   #   image: plugins/git
   #   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ pipeline:
       - DOCKER_HOST=tcp://172.17.0.1:2375
     commands:
       - docker run -d --name=redis-$${DRONE_COMMIT_SHA} redis
-      - docker run -d -e NODE_ENV=ci --name=app-$${DRONE_COMMIT_SHA} --net=container:redis-$${DRONE_COMMIT_SHA} pttg-euro-tlr-enquiry
+      - docker run -d -e NODE_ENV=ci --name=app-$${DRONE_COMMIT_SHA} --net=container:redis-$${DRONE_COMMIT_SHA} pttg-euro-tlr-enquiry-form
       - docker run -d --net=container:app-$${DRONE_COMMIT_SHA} --name=selenium-$${DRONE_COMMIT_SHA} selenium/standalone-chrome
       - docker run --rm --net=container:selenium-$${DRONE_COMMIT_SHA} -e SELENIUM_TCP=tcp://localhost:4444 martin/wait
       - docker run --rm --net=container:app-$${DRONE_COMMIT_SHA} test-$${DRONE_COMMIT_SHA}
@@ -52,8 +52,8 @@ pipeline:
       - docker_password
     commands:
       - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
     when:
       event: push
 
@@ -65,8 +65,8 @@ pipeline:
       - docker_password
     commands:
       - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_BRANCH}
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_BRANCH}
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_BRANCH}
     when:
       branch:
         exclude: master
@@ -80,10 +80,10 @@ pipeline:
       - docker_password
     commands:
       - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:latest
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:latest
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:build-$${DRONE_BUILD_NUMBER}
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:build-$${DRONE_BUILD_NUMBER}
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:latest
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:build-$${DRONE_BUILD_NUMBER}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:build-$${DRONE_BUILD_NUMBER}
     when:
       branch: master
       event: push
@@ -96,10 +96,10 @@ pipeline:
       - docker_password
     commands:
       - docker login -u="ukhomeofficedigital+pttg" -p=$${DOCKER_PASSWORD} quay.io
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:$${DRONE_TAG}
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:$${DRONE_TAG}
-      - docker tag pttg-euro-tlr-enquiry quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
-      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry:${DRONE_COMMIT_SHA:0:8}
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:$${DRONE_TAG}
+      - docker tag pttg-euro-tlr-enquiry-form quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
+      - docker push quay.io/ukhomeofficedigital/pttg-euro-tlr-enquiry-form:${DRONE_COMMIT_SHA:0:8}
     when:
       event: tag
 


### PR DESCRIPTION
Uncommented all the testing steps of .drone.yml and setup pushing of images to Quay. I have done a workflow more like other pttg projects, with feature branch images being pushed, than the other enquiry form has.

I had the credentials for the Quay robot with the username ukhomeofficedigital+pttg_ip_smoke_tests to hand so I've used them. I think this is fine but I can raise an ACP ticket for a new robot if there's any disagreement on that.