### PR TITLE
Ee 26903 deploy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -125,7 +125,7 @@ pipeline:
     secrets:
       - pttg_rps_dev
     commands:
-      - export WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
+      - export WHITELIST="$${POISE_RANGES},$${GOVWIFI_RANGES},$${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:
@@ -146,7 +146,7 @@ pipeline:
       - pttg_rps_test
       - notify_recipient_notprod
     commands:
-      - export WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
+      - export WHITELIST="$${POISE_RANGES},$${GOVWIFI_RANGES},$${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -125,7 +125,7 @@ pipeline:
     secrets:
       - pttg_rps_dev
     commands:
-      - WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
+      - export WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:
@@ -146,7 +146,7 @@ pipeline:
       - pttg_rps_test
       - notify_recipient_notprod
     commands:
-      - WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
+      - export WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -119,13 +119,9 @@ pipeline:
       - ENVIRONMENT=dev
       - VERSION=build-${DRONE_BUILD_NUMBER}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      - POISE_RANGES=62.25.109.196/32,52.209.62.128/25
-      - GOVWIFI_RANGES=167.98.162.0/25,167.98.158.128/25
-      - ACPTUNNEL_RANGES=52.56.221.216/32,18.130.11.142/32,18.130.6.5/32
     secrets:
       - pttg_rps_dev
     commands:
-      - export WHITELIST="$${POISE_RANGES},$${GOVWIFI_RANGES},$${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:
@@ -138,15 +134,11 @@ pipeline:
       - KUBE_NAMESPACE=pttg-rps-enquiry-${DRONE_DEPLOY_TO}
       - ENVIRONMENT=${DRONE_DEPLOY_TO}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      - POISE_RANGES=62.25.109.196/32,52.209.62.128/25
-      - GOVWIFI_RANGES=167.98.162.0/25,167.98.158.128/25
-      - ACPTUNNEL_RANGES=52.56.221.216/32,18.130.11.142/32,18.130.6.5/32
     secrets:
       - pttg_rps_dev
       - pttg_rps_test
       - notify_recipient_notprod
     commands:
-      - export WHITELIST="$${POISE_RANGES},$${GOVWIFI_RANGES},$${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -119,10 +119,13 @@ pipeline:
       - ENVIRONMENT=dev
       - VERSION=build-${DRONE_BUILD_NUMBER}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
+      - POISE_RANGES=62.25.109.196/32,52.209.62.128/25
+      - GOVWIFI_RANGES=167.98.162.0/25,167.98.158.128/25
+      - ACPTUNNEL_RANGES=52.56.221.216/32,18.130.11.142/32,18.130.6.5/32
     secrets:
       - pttg_rps_dev
     commands:
+      - WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:
@@ -135,12 +138,15 @@ pipeline:
       - KUBE_NAMESPACE=pttg-rps-enquiry-${DRONE_DEPLOY_TO}
       - ENVIRONMENT=${DRONE_DEPLOY_TO}
       - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
+      - POISE_RANGES=62.25.109.196/32,52.209.62.128/25
+      - GOVWIFI_RANGES=167.98.162.0/25,167.98.158.128/25
+      - ACPTUNNEL_RANGES=52.56.221.216/32,18.130.11.142/32,18.130.6.5/32
     secrets:
       - pttg_rps_dev
       - pttg_rps_test
       - notify_recipient_notprod
     commands:
+      - WHITELIST="${POISE_RANGES},${GOVWIFI_RANGES},${ACPTUNNEL_RANGES}"
       - cd kube-pttg-euro-tlr-enquiry-form
       - ./deploy.sh
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -103,64 +103,62 @@ pipeline:
     when:
       event: tag
 
-  # clone-kube-project:
-  #   image: plugins/git
-  #   commands:
-  #     - git clone https://github.com/UKHomeOffice/kube-pttg-rps-enquiry-form.git
-  #     - cd kube-pttg-rps-enquiry-form
-  #     - git checkout $${KUBE_BRANCH:=master}
-  #   when:
-  #     event: [push, deployment, tag]
-  #
-  # deploy-to-dev-from-build-number:
-  #   image: quay.io/ukhomeofficedigital/kd:latest
-  #   environment:
-  #     - KUBE_NAMESPACE=pttg-rps-enquiry-dev
-  #     - ENVIRONMENT=dev
-  #     - VERSION=build-${DRONE_BUILD_NUMBER}
-  #     - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-  #     - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
-  #   secrets:
-  #     - pttg_rps_dev
-  #     - basic_auth
-  #   commands:
-  #     - cd kube-pttg-rps-enquiry-form
-  #     - ./deploy.sh
-  #   when:
-  #     branch: master
-  #     event: [push, tag]
-  #
-  # deployment:
-  #   image: quay.io/ukhomeofficedigital/kd:latest
-  #   environment:
-  #     - KUBE_NAMESPACE=pttg-rps-enquiry-${DRONE_DEPLOY_TO}
-  #     - ENVIRONMENT=${DRONE_DEPLOY_TO}
-  #     - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-  #     - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
-  #   secrets:
-  #     - pttg_rps_dev
-  #     - pttg_rps_test
-  #     - basic_auth
-  #     - notify_recipient_notprod
-  #   commands:
-  #     - cd kube-pttg-rps-enquiry-form
-  #     - ./deploy.sh
-  #   when:
-  #     event: deployment
-  #     environment: [dev, test]
-  #
-  # deploy-to-prod:
-  #   image: quay.io/ukhomeofficedigital/kd:latest
-  #   environment:
-  #     - KUBE_NAMESPACE=pttg-rps-enquiry-pr
-  #     - ENVIRONMENT=pr
-  #     - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-  #   secrets:
-  #     - pttg_rps_pr
-  #     - notify_recipient_prod
-  #   commands:
-  #     - cd kube-pttg-rps-enquiry-form
-  #     - ./deploy.sh
-  #   when:
-  #     event: deployment
-  #     environment: pr
+  clone-kube-project:
+    image: plugins/git
+    commands:
+      - git clone https://github.com/UKHomeOffice/kube-pttg-euro-tlr-enquiry-form.git
+      - cd kube-pttg-euro-tlr-enquiry-form
+      - git checkout $${KUBE_BRANCH:=master}
+    when:
+      event: [push, deployment, tag]
+
+  deploy-to-dev-from-build-number:
+    image: quay.io/ukhomeofficedigital/kd:latest
+    environment:
+      - KUBE_NAMESPACE=pttg-rps-enquiry-dev
+      - ENVIRONMENT=dev
+      - VERSION=build-${DRONE_BUILD_NUMBER}
+      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
+    secrets:
+      - pttg_rps_dev
+    commands:
+      - cd kube-pttg-euro-tlr-enquiry-form
+      - ./deploy.sh
+    when:
+      branch: master
+      event: [push, tag]
+
+  deployment:
+    image: quay.io/ukhomeofficedigital/kd:latest
+    environment:
+      - KUBE_NAMESPACE=pttg-rps-enquiry-${DRONE_DEPLOY_TO}
+      - ENVIRONMENT=${DRONE_DEPLOY_TO}
+      - KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      - WHITELIST=62.25.109.196/32,52.48.127.150/32,52.48.127.151/32,52.48.127.152/32,52.48.127.153/32,52.209.62.128/25,52.56.62.128/25,185.22.224.96,185.22.224.96/32,185.22.226.96/32,213.251.23.180/30,213.251.23.184/30,213.251.23.188/30,148.253.134.213/32,167.98.162.0/25,167.98.158.128/25
+    secrets:
+      - pttg_rps_dev
+      - pttg_rps_test
+      - notify_recipient_notprod
+    commands:
+      - cd kube-pttg-euro-tlr-enquiry-form
+      - ./deploy.sh
+    when:
+      event: deployment
+      environment: [dev, test]
+
+  deploy-to-prod:
+    image: quay.io/ukhomeofficedigital/kd:latest
+    environment:
+      - KUBE_NAMESPACE=pttg-rps-enquiry-pr
+      - ENVIRONMENT=pr
+      - KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
+    secrets:
+      - pttg_rps_pr
+      - notify_recipient_prod
+    commands:
+      - cd kube-pttg-euro-tlr-enquiry-form
+      - ./deploy.sh
+    when:
+      event: deployment
+      environment: pr

--- a/config.js
+++ b/config.js
@@ -26,8 +26,8 @@ module.exports = {
         cookie: {secure: (process.env.NODE_ENV === 'production')}
     },
     redis: {
-        host: process.env.REDIS_SERVICE_HOST || process.env.REDIS_HOST || 'localhost',
-        port: process.env.REDIS_SERVICE_PORT || process.env.REDIS_PORT || 6379,
+        host: process.env.REDIS_HOST || 'localhost',
+        port: process.env.REDIS_PORT || 6379,
         password: process.env.REDIS_PASSWORD || null
     },
     gaTagId: process.env.GOOGLE_ANALYTICS_UA || 'UA-84737854-3',


### PR DESCRIPTION
Set up the deployment in .drone.yml. 
Also changed the expected Environment Variable name for the Redis Host/Port. The old name relies on the redis service being called 'redis-service' (which it isn't for this app). It seems Kubernetes sets the REDIS_SERVICE_HOST and REDIS_SERVICE_PORT environement variables based on the service name.

This means that the value cannot be set by config, there is a needless coupling between the app and its redis service, and the deployment didn't work until I changed this.

Accompanying Kube PR: https://github.com/UKHomeOffice/kube-pttg-euro-tlr-enquiry-form/pull/5

As the app isn't used yet I intend to merge once approved.