### PR TITLE
Ee 27627

### DIFF
--- a/apps/pttg-euro-tlr-enquiry-form/translations/src/cy/leave.json
+++ b/apps/pttg-euro-tlr-enquiry-form/translations/src/cy/leave.json
@@ -1,5 +1,4 @@
 {
-  "thank-you": "Diolch yn fawr",
   "left-the-service": "Rydych nawr wedi gadael y gwasanaeth.",
   "what-did-you-think" : "Beth oeddech chi’n ei feddwl o’r gwasanaeth hwn?",
   "takes-30-seconds": ", (mae’n cymryd 30 eiliad)",

--- a/apps/pttg-euro-tlr-enquiry-form/translations/src/cy/pages.json
+++ b/apps/pttg-euro-tlr-enquiry-form/translations/src/cy/pages.json
@@ -1,6 +1,6 @@
 {
   "start": {
-    "heading": "Gofynnwch gwestiwn ynglŷn â gwneud cais am Ganiatâd i Aros Dros Dro Ewropeaidd (Euro TLR)"
+    "header": "Gofynnwch gwestiwn ynglŷn â gwneud cais am Ganiatâd i Aros Dros Dro Ewropeaidd (Euro TLR)"
   },
   "question": {
     "header": "Eich cwestiwn a manylion cyswllt"
@@ -40,5 +40,8 @@
   },
   "confirmation": {
     "panel": "Mae eich cwestiwn wedi cael ei anfon"
+  },
+  "leave": {
+    "header": "Diolch yn fawr"
   }
 }

--- a/apps/pttg-euro-tlr-enquiry-form/translations/src/en/leave.json
+++ b/apps/pttg-euro-tlr-enquiry-form/translations/src/en/leave.json
@@ -1,5 +1,4 @@
 {
-  "thank-you": "Thank you",
   "left-the-service": "You have now left the service.",
   "what-did-you-think" : "What did you think of this service?",
   "takes-30-seconds": ",(takes 30 seconds)",

--- a/apps/pttg-euro-tlr-enquiry-form/translations/src/en/pages.json
+++ b/apps/pttg-euro-tlr-enquiry-form/translations/src/en/pages.json
@@ -40,5 +40,8 @@
   },
   "confirmation": {
     "panel": "Your question has been sent"
+  },
+  "leave": {
+    "header": "Thank you"
   }
 }

--- a/apps/pttg-euro-tlr-enquiry-form/translations/src/en/pages.json
+++ b/apps/pttg-euro-tlr-enquiry-form/translations/src/en/pages.json
@@ -1,6 +1,6 @@
 {
   "start": {
-    "heading": "Ask a question about applying for European Temporary Leave to Remain (Euro TLR)"
+    "header": "Ask a question about applying for European Temporary Leave to Remain (Euro TLR)"
   },
   "question": {
     "header": "Your question and contact details"

--- a/apps/pttg-euro-tlr-enquiry-form/views/leave.html
+++ b/apps/pttg-euro-tlr-enquiry-form/views/leave.html
@@ -4,10 +4,6 @@
 <div class="grid-row">
     <div class="column-full">
 
-        <h1 class="heading-large">
-            {{#t}}leave.thank-you{{/t}}
-        </h1>
-
         <p>{{#t}}leave.left-the-service{{/t}}</p>
         <p><a id="feedback" href="https://www.gov.uk/done/european-temporary-leave-to-remain-enquiries">{{#t}}leave.what-did-you-think{{/t}}</a>{{#t}}leave.takes-30-seconds{{/t}}</p>
         <p><strong>{{#t}}leave.you-can-also{{/t}}</strong></p>

--- a/apps/pttg-euro-tlr-enquiry-form/views/start.html
+++ b/apps/pttg-euro-tlr-enquiry-form/views/start.html
@@ -1,8 +1,5 @@
 {{<partials-page}}
     {{$page-content}}
-        <h1 class="heading-large">
-            {{#t}}pages.start.heading{{/t}}
-        </h1>
         <div id="markdown">
             {{#markdown}}start-now{{/markdown}}
         </div>


### PR DESCRIPTION
This to fix a couple of accessibility issues. HOF template partials provides a level 1 heading to all pages which incorporate the govuk-template as the ETLR form does.
This meant that where ever we provided our own header, pages were being rendered with a duplicate <h1> coming from HOF which was empty causing potential issues for assisted digital users. 
This removes our use of headings and instead uses the ones provided by HOF.